### PR TITLE
Update setup-landscape.sh

### DIFF
--- a/steps/setup-landscape.sh
+++ b/steps/setup-landscape.sh
@@ -3,4 +3,4 @@ sudo apt-get -qqyf install landscape-api > /dev/null 2>&1
 CREDS=$(landscape-api call BootstrapLDS --json admin_email="$LDS_EMAIL" admin_name="$LDS_NAME" admin_password="$LDS_PASSWORD" --uri https://$HAPROXY/api/ --ssl-ca-file /etc/ssl/certs/landscape_server_ca.crt)
 export LANDSCAPE_API_KEY=$(echo $CREDS|python -c "import sys,yaml; print(yaml.load(sys.stdin))['LANDSCAPE_API_KEY']")
 export LANDSCAPE_API_SECRET=$(echo $CREDS|python -c "import sys,yaml; print(yaml.load(sys.stdin))['LANDSCAPE_API_SECRET']")
-landscape-api register-maas-region-controller --json "http://$MAAS_ENDPOINT/MAAS/" "$MAAS_APIKEY" --uri https://$HAPROXY/api/ --ssl-ca-file /etc/ssl/certs/landscape_server_ca.crt > /dev/null 2>&1
+landscape-api register-maas-region-controller --json "http://$MAAS_ENDPOINT/MAAS/" "$MAAS_APIKEY" --uri https://$HAPROXY/api/ --ssl-ca-file /etc/ssl/certs/landscape_server_ca.crt || /bin/true


### PR DESCRIPTION
rediret output to logfile, don't care if the maas api call fails.  (the landscape UI handles this case already)